### PR TITLE
feat: Add LaTeX paper structure to neural_algorithm

### DIFF
--- a/neural_algorithm/README.md
+++ b/neural_algorithm/README.md
@@ -1,0 +1,11 @@
+# Neural Algorithm Paper
+
+This directory contains the LaTeX source for the paper "A Neural Algorithm for...", as well as the code for the numerical experiments.
+
+## Directory Structure
+
+- `paper.tex`: The main LaTeX file for the paper.
+- `references.bib`: The bibliography file for the paper.
+- `code/`: Contains the code for the numerical experiments.
+- `figures/`: Contains the figures for the paper.
+- `styles/`: Contains any custom style files for the paper.

--- a/neural_algorithm/paper.tex
+++ b/neural_algorithm/paper.tex
@@ -1,0 +1,32 @@
+\documentclass{article}
+\usepackage{graphicx}
+\usepackage{amsmath}
+
+\title{A Neural Algorithm for \dots}
+\author{Jules}
+\date{\today}
+
+\begin{document}
+
+\maketitle
+
+\begin{abstract}
+% Abstract goes here
+\end{abstract}
+
+\section{Introduction}
+% Introduction goes here
+
+\section{Methods}
+% Methods go here
+
+\section{Numerical Experiments}
+% Numerical experiments go here
+
+\section{Conclusion}
+% Conclusion goes here
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+\end{document}

--- a/neural_algorithm/references.bib
+++ b/neural_algorithm/references.bib
@@ -1,0 +1,8 @@
+% This is the bibliography file.
+% Entries can be added in BibTeX format.
+@article{example,
+  title={Example Article},
+  author={Author, A. N.},
+  journal={Journal of Examples},
+  year={2023},
+}


### PR DESCRIPTION
This commit refactors the `neural_algorithm` directory to include a standard structure for a LaTeX research paper.

The following has been added:
- `paper.tex`: The main LaTeX file for the paper.
- `references.bib`: A BibTeX file for managing references.
- `README.md`: A file explaining the directory layout.
- `code/`: A directory to hold code for numerical experiments.
- `figures/`: A directory to store figures for the paper.
- `styles/`: A directory for custom LaTeX style files.