### PR TITLE
Fix undefined internal reference in pi manuscript

### DIFF
--- a/pi/pi.tex
+++ b/pi/pi.tex
@@ -367,7 +367,7 @@ Laziness ensures the walk is aperiodic, simplifying spectral analysis. It also r
 
 
 \begin{remark}[Measures and Operators]\label{rem:measures_operators}
-The LSRW is reversible w.r.t. the degree measure $m(x)=\deg(x)$. The Laplacian $\LL$ is self-adjoint on the Hilbert space $\ell^2(m)$. Due to the assumption of bounded degree ($\Delta < \infty$), the counting measure $|\cdot|$ and the degree measure $m$ are comparable: $m(A) \asymp |A|$. This allows seamless transition between analytic results formulated w.r.t. $m$ (such as those in \Cref{lem:IU_derivation}) and geometric properties formulated w.r.t. $|\cdot|$ (see \cite{Coulhon03}).
+The LSRW is reversible w.r.t. the degree measure $m(x)=\deg(x)$. The Laplacian $\LL$ is self-adjoint on the Hilbert space $\ell^2(m)$. Due to the assumption of bounded degree ($\Delta < \infty$), the counting measure $|\cdot|$ and the degree measure $m$ are comparable: $m(A) \asymp |A|$. This allows seamless transition between analytic results formulated w.r.t. $m$ (such as those in \Cref{prop:LT}) and geometric properties formulated w.r.t. $|\cdot|$ (see \cite{Coulhon03}).
 
 
 On a finite subgraph $H$, the Dirichlet Laplacian $\LL_H$ acting on $\ell^2(m|_H)$ is similar to the operator acting on $\ell^2(|\cdot||_H)$ (via the transformation induced by the square root of the measure densities, $M^{1/2}$). Since the trace is similarity-invariant in finite dimensions, $Z_H(1) = \tr(\LL_H^{-1})$ is independent of the chosen (comparable) inner product.


### PR DESCRIPTION
### Motivation
- Resolve a broken cross-reference in the `pi` paper where an undefined label caused LaTeX warnings and potential confusion about the long-time/Intrinsic Ultracontractivity reference.

### Description
- Replaced the invalid reference `\Cref{lem:IU_derivation}` with the correct existing label `\Cref{prop:LT}` in `pi/pi.tex` so the text points to the proposition that provides the long-time Dirichlet / IU input.

### Testing
- Ran a programmatic label/ref check via `python` to verify there are no unresolved internal `\Cref{...}/\cref{...}/\ref{...}` references and the check passed; the modified file is `pi/pi.tex`.
- Ran a programmatic `\cite{...}` vs `\bibitem{...}` check via `python` and confirmed no missing bibliography keys.
- Attempted to build the PDF with `pdflatex` but it is not available in this environment, so full PDF compilation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c90e9811c4832abf2b168c88f8eedf)